### PR TITLE
Update to use newer and maintained packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var HashRing = require('hash_ring');
+var HashRing = require('hashring');
 var redis = require('redis');
 var step = require('step');
 
@@ -41,7 +41,7 @@ module.exports = function RedisShard(options) {
   ];
   SHARDABLE.forEach(function(command) {
     self[command] = function() {
-      var node = ring.getNode(arguments[0]);
+      var node = ring.get(arguments[0]);
       var client = clients[node];
       client[command].apply(client, arguments);
     };
@@ -73,7 +73,7 @@ module.exports = function RedisShard(options) {
     // Setup chainable shardable commands
     SHARDABLE.forEach(function(command) {
       self[command] = function() {
-        var node = ring.getNode(arguments[0]);
+        var node = ring.get(arguments[0]);
         var multi = multis[node];
         if (!multi) {
           multi = multis[node] = clients[node].multi();

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "hash_ring": "0.2.1",
-    "redis": "0.8.2",
+    "hashring": "2.0.1",
+    "redis": "0.10.3",
     "step": "0.0.5"
   },
   "engines": {


### PR DESCRIPTION
In particular, [`hash_ring`](https://www.npmjs.org/package/hash_ring) is no longer maintained but [`hashring`](https://www.npmjs.org/package/hashring) is.
