### PR TITLE
if self is suppose to be public, don't overwrite it in this method

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,6 @@ module.exports = function RedisShard(options) {
   // This is the tricky part - pipeline commands to multiple servers
   self.multi = function Multi() {
 
-    var self = {};
     var multis = {};
     var interlachen = [];
 


### PR DESCRIPTION
var self = {}; // was re-initialized rendering multi() useless...
